### PR TITLE
Clear GPT and MBR headers with dd to avoid sgdisk CRC errors

### DIFF
--- a/ironic_python_agent/shell/write_image.sh
+++ b/ironic_python_agent/shell/write_image.sh
@@ -36,6 +36,12 @@ DEVICE="$2"
 # In production this will be replaced with secure erasing the drives
 # For now we need to ensure there aren't any old (GPT) partitions on the drive
 log "Erasing existing GPT and MBR data structures from ${DEVICE}"
+
+# NOTE(gfidente): GPT uses 33*512 sectors, this is an attempt to avoid bug:
+# https://bugs.launchpad.net/ironic-python-agent/+bug/1737556
+DEVICE_SECTORS_COUNT=`blockdev --getsz $DEVICE`
+dd bs=512 if=/dev/zero of=$DEVICE count=33
+dd bs=512 if=/dev/zero of=$DEVICE count=33 seek=$((${DEVICE_SECTORS_COUNT} - 33))
 sgdisk -Z $DEVICE
 
 log "Imaging $IMAGEFILE to $DEVICE"


### PR DESCRIPTION
Cherry pick of upstream fix. Seen this during cleaning on Alaska p3.

This change adds a dd before the existing sgdisk -Z command to
workaround CRC verification errors.

Change-Id: Ia1ac4e1c0faf14ad4bb11c2a1c796c93ca8cb5e3
Closes-Bug: #1737556
Story: 1737556
Task: 11496
This change adds a dd before the existing sgdisk -Z command to
workaround CRC verification errors.