### PR TITLE
Xena: Backport SMART warning

### DIFF
--- a/ironic_python_agent/hardware.py
+++ b/ironic_python_agent/hardware.py
@@ -1748,10 +1748,11 @@ class GenericHardwareManager(HardwareManager):
                         'ATA commands via the `smartctl` utility with device '
                         '%s do not succeed.', block_device.name)
             return False
-        except OSError:
+        except OSError as e:
             # Processutils can raise OSError if a path is not found,
             # and it is okay that we tollerate that since it was the
             # prior behavior.
+            LOG.warning('Unable to execute `smartctl` utility: %s', e)
             return True
 
     def _ata_erase(self, block_device):


### PR DESCRIPTION
Currently, if smartctl is not found by IPA, it will silently skip ATA secure erase and proceed to shred (if enabled). This is supposedly for backwards compatibility, but is quite hard to diagnose.

This change adds a warning message to make it more obvious what is happening.

TrivialFix

Change-Id: I03a381e99de79f201ec7e9a388777c3d48457e93